### PR TITLE
Fix for predictive text

### DIFF
--- a/sbapp/ui/messages.py
+++ b/sbapp/ui/messages.py
@@ -711,6 +711,7 @@ MDScreen:
             MDTextField:
                 id: message_text
                 keyboard_suggestions: True
+                input_type: "text"
                 multiline: True
                 hint_text: "Write message"
                 mode: "rectangle"


### PR DESCRIPTION
Kivy's default for input boxes changed from "text" to "null" in Kivy 2.1.0. Not specifying it disallowed typing using predictive text keyboards such as Gboard or Swiftkey swiping, which was irritating, when you are typing text messages.